### PR TITLE
add license to concepts

### DIFF
--- a/src/Item.php
+++ b/src/Item.php
@@ -13,6 +13,7 @@ class Item extends Resource
         'url'           => 'URL',
         'identifier'    => ['Listing'],
         'notation'      => ['Listing'],
+        'license'       => ['Set', 'Concept'],
         'prefLabel'     => 'LanguageMapOfStrings',
         'altLabel'      => 'LanguageMapOfLists',
         'hiddenLabel'   => 'LanguageMapOfLists',


### PR DESCRIPTION
always show license in http://uri.gbv.de/terminology/
see https://github.com/gbv/uri-gbv-terminology/issues/11